### PR TITLE
Fix nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -19,16 +19,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1756911493,
-        "narHash": "sha256-6n/n1GZQ/vi+LhFXMSyoseKdNfc2QQaSBXJdgamrbkE=",
+        "lastModified": 1760423683,
+        "narHash": "sha256-Tb+NYuJhWZieDZUxN6PgglB16yuqBYQeMJyYBGCXlt8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c6a788f552b7b7af703b1a29802a7233c0067908",
+        "rev": "a493e93b4a259cd9fea8073f89a7ed9b1c5a1da2",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
+        "ref": "nixos-25.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Example flake environment for build buildroot projects";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
   };
 
   outputs = inputs@{ flake-parts, ... }:
@@ -14,7 +14,8 @@
           name = "buildroot";
           targetPkgs = pkgs: (with pkgs;
             [
-              (lib.hiPrio gcc)
+              (lib.hiPrio gcc12)
+              (lib.hiPrio gcc12Stdenv)
               bashInteractive
               bc
               binutils
@@ -28,7 +29,6 @@
               file
               findutils
               flock
-              gcc
               glib # not mentioned; not sure if necessary
               glibc # transitively mentioned: debian build-essential
               gnumake


### PR DESCRIPTION
I was having issues building on my NixOS machine. I think this was because the GCC/etc. versions weren't set to high priority. This is also tying the versions to a stable release.